### PR TITLE
fix consumer metrics

### DIFF
--- a/endpoints-control/src/main/java/com/google/api/control/model/KnownMetrics.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/KnownMetrics.java
@@ -34,19 +34,11 @@ public enum KnownMetrics {
   PRODUCER_REQUEST_COUNT("serviceruntime.googleapis.com/api/producer/request_count",
       MetricKind.DELTA, ValueType.INT64, add1ToInt64Metric()),
 
-  PRODUCER_BY_CONSUMER_REQUEST_COUNT(
-      "serviceruntime.googleapis.com/api/producer/by_consumer/request_count", MetricKind.DELTA,
-      ValueType.INT64, add1ToInt64Metric()),
-
   CONSUMER_REQUEST_SIZES("serviceruntime.googleapis.com/api/consumer/request_sizes",
       MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForRequestSize()),
 
   PRODUCER_REQUEST_SIZES("serviceruntime.googleapis.com/api/producer/request_sizes",
       MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForRequestSize()),
-
-  PRODUCER_BY_CONSUMER_REQUEST_SIZES(
-      "serviceruntime.googleapis.com/api/producer/by_consumer/request_sizes", MetricKind.DELTA,
-      ValueType.DISTRIBUTION, addDistributionMetricForRequestSize()),
 
   CONSUMER_RESPONSE_SIZES("serviceruntime.googleapis.com/api/consumer/response_sizes",
       MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForResponseSize()),
@@ -54,19 +46,11 @@ public enum KnownMetrics {
   PRODUCER_RESPONSE_SIZES("serviceruntime.googleapis.com/api/producer/response_sizes",
       MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForResponseSize()),
 
-  PRODUCER_BY_CONSUMER_RESPONSE_SIZES(
-      "serviceruntime.googleapis.com/api/producer/by_consumer/response_sizes", MetricKind.DELTA,
-      ValueType.DISTRIBUTION, addDistributionMetricForResponseSize()),
-
   CONSUMER_REQUEST_ERROR_COUNT("serviceruntime.googleapis.com/api/consumer/error_count",
       MetricKind.DELTA, ValueType.INT64, add1ToInt64MetricIfError()),
 
   PRODUCER_REQUEST_ERROR_COUNT("serviceruntime.googleapis.com/api/producer/error_count",
       MetricKind.DELTA, ValueType.INT64, add1ToInt64MetricIfError()),
-
-  PRODUCER_BY_CONSUMER_ERROR_COUNT(
-      "serviceruntime.googleapis.com/api/producer/by_consumer/error_count", MetricKind.DELTA,
-      ValueType.INT64, add1ToInt64MetricIfError()),
 
   CONSUMER_TOTAL_LATENCIES("serviceruntime.googleapis.com/api/consumer/total_latencies",
       MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForRequestTimeMillis()),
@@ -74,19 +58,11 @@ public enum KnownMetrics {
   PRODUCER_TOTAL_LATENCIES("serviceruntime.googleapis.com/api/producer/total_latencies",
       MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForRequestTimeMillis()),
 
-  PRODUCER_BY_CONSUMER_TOTAL_LATENCIES(
-      "serviceruntime.googleapis.com/api/producer/by_consumer/total_latencies", MetricKind.DELTA,
-      ValueType.DISTRIBUTION, addDistributionMetricForRequestTimeMillis()),
-
   CONSUMER_BACKEND_LATENCIES("serviceruntime.googleapis.com/api/consumer/backend_latencies",
       MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForBackendTimeMillis()),
 
   PRODUCER_BACKEND_LATENCIES("serviceruntime.googleapis.com/api/producer/backend_latencies",
       MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForBackendTimeMillis()),
-
-  PRODUCER_BY_CONSUMER_BACKEND_LATENCIES(
-      "serviceruntime.googleapis.com/api/producer/by_consumer/backend_latencies", MetricKind.DELTA,
-      ValueType.DISTRIBUTION, addDistributionMetricForBackendTimeMillis()),
 
   CONSUMER_REQUEST_OVERHEAD_LATENCIES(
       "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies", MetricKind.DELTA,
@@ -94,11 +70,7 @@ public enum KnownMetrics {
 
   PRODUCER_REQUEST_OVERHEAD_LATENCIES(
       "serviceruntime.googleapis.com/api/producer/request_overhead_latencies", MetricKind.DELTA,
-      ValueType.DISTRIBUTION, addDistributionMetricForOverheadTimeMillis()),
-
-  PRODUCER_BY_CONSUMER_REQUEST_OVERHEAD_LATENCIES(
-      "serviceruntime.googleapis.com/api/producer/by_consumer/request_overhead_latencies",
-      MetricKind.DELTA, ValueType.DISTRIBUTION, addDistributionMetricForOverheadTimeMillis());
+      ValueType.DISTRIBUTION, addDistributionMetricForOverheadTimeMillis());
 
   private static final double TIME_SCALE = 1e-6;
   private static final double SIZE_SCALE = 1;

--- a/endpoints-control/src/test/java/com/google/api/control/ControlFilterTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/ControlFilterTest.java
@@ -176,8 +176,7 @@ public class ControlFilterTest {
   @Test
   public void shouldSetBackendLatency() throws IOException, ServletException {
     HashSet<String> wantMetricNames =
-        Sets.newHashSet(KnownMetrics.CONSUMER_BACKEND_LATENCIES.getName(),
-            KnownMetrics.PRODUCER_BACKEND_LATENCIES.getName());
+        Sets.newHashSet(KnownMetrics.PRODUCER_BACKEND_LATENCIES.getName());
     rule = ReportingRule.fromKnownInputs(null, wantMetricNames, null);
     mockRequestAndResponse();
     when(client.check(any(CheckRequest.class))).thenReturn(checkResponse);
@@ -191,7 +190,7 @@ public class ControlFilterTest {
 
     // verify that the report includes the specified metrics
     List<MetricValueSet> mvs = op.getMetricValueSetsList();
-    assertThat(mvs.size()).isEqualTo(2);
+    assertThat(mvs.size()).isEqualTo(1);
     Set<String> gotMetricNames = Sets.newHashSet();
     for (MetricValueSet s : mvs) {
       gotMetricNames.add(s.getMetricName());

--- a/endpoints-control/src/test/java/com/google/api/control/ControlFilterTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/ControlFilterTest.java
@@ -177,8 +177,7 @@ public class ControlFilterTest {
   public void shouldSetBackendLatency() throws IOException, ServletException {
     HashSet<String> wantMetricNames =
         Sets.newHashSet(KnownMetrics.CONSUMER_BACKEND_LATENCIES.getName(),
-            KnownMetrics.PRODUCER_BACKEND_LATENCIES.getName(),
-            KnownMetrics.PRODUCER_BY_CONSUMER_BACKEND_LATENCIES.getName());
+            KnownMetrics.PRODUCER_BACKEND_LATENCIES.getName());
     rule = ReportingRule.fromKnownInputs(null, wantMetricNames, null);
     mockRequestAndResponse();
     when(client.check(any(CheckRequest.class))).thenReturn(checkResponse);
@@ -192,7 +191,7 @@ public class ControlFilterTest {
 
     // verify that the report includes the specified metrics
     List<MetricValueSet> mvs = op.getMetricValueSetsList();
-    assertThat(mvs.size()).isEqualTo(3);
+    assertThat(mvs.size()).isEqualTo(2);
     Set<String> gotMetricNames = Sets.newHashSet();
     for (MetricValueSet s : mvs) {
       gotMetricNames.add(s.getMetricName());

--- a/endpoints-control/src/test/java/com/google/api/control/model/KnownMetricsTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/model/KnownMetricsTest.java
@@ -57,29 +57,19 @@ public class KnownMetricsTest {
   private static final StructuredTest[] ALL_TESTS = {
       new StructuredTest(KnownMetrics.CONSUMER_REQUEST_SIZES, KnownMetrics.newSizeDistribution()),
       new StructuredTest(KnownMetrics.PRODUCER_REQUEST_SIZES, KnownMetrics.newSizeDistribution()),
-      new StructuredTest(KnownMetrics.PRODUCER_BY_CONSUMER_REQUEST_SIZES,
-          KnownMetrics.newSizeDistribution()),
       new StructuredTest(KnownMetrics.CONSUMER_RESPONSE_SIZES, KnownMetrics.newSizeDistribution()),
       new StructuredTest(KnownMetrics.PRODUCER_RESPONSE_SIZES, KnownMetrics.newSizeDistribution()),
-      new StructuredTest(KnownMetrics.PRODUCER_BY_CONSUMER_RESPONSE_SIZES,
-          KnownMetrics.newSizeDistribution()),
       new StructuredTest(KnownMetrics.CONSUMER_TOTAL_LATENCIES,
           KnownMetrics.newTimeDistribution(), true),
       new StructuredTest(KnownMetrics.PRODUCER_TOTAL_LATENCIES,
-          KnownMetrics.newTimeDistribution(), true),
-      new StructuredTest(KnownMetrics.PRODUCER_BY_CONSUMER_TOTAL_LATENCIES,
           KnownMetrics.newTimeDistribution(), true),
       new StructuredTest(KnownMetrics.CONSUMER_BACKEND_LATENCIES,
           KnownMetrics.newTimeDistribution(), true),
       new StructuredTest(KnownMetrics.PRODUCER_BACKEND_LATENCIES,
           KnownMetrics.newTimeDistribution(), true),
-      new StructuredTest(KnownMetrics.PRODUCER_BY_CONSUMER_BACKEND_LATENCIES,
-          KnownMetrics.newTimeDistribution(), true),
       new StructuredTest(KnownMetrics.CONSUMER_REQUEST_OVERHEAD_LATENCIES,
           KnownMetrics.newTimeDistribution(), true),
       new StructuredTest(KnownMetrics.PRODUCER_REQUEST_OVERHEAD_LATENCIES,
-          KnownMetrics.newTimeDistribution(), true),
-      new StructuredTest(KnownMetrics.PRODUCER_BY_CONSUMER_REQUEST_OVERHEAD_LATENCIES,
           KnownMetrics.newTimeDistribution(), true),
       new StructuredTest(KnownMetrics.CONSUMER_REQUEST_COUNT, MetricValueSet
           .newBuilder()
@@ -90,12 +80,6 @@ public class KnownMetricsTest {
           MetricValueSet
               .newBuilder()
               .setMetricName(KnownMetrics.PRODUCER_REQUEST_COUNT.getName())
-              .addMetricValues(MetricValue.newBuilder().setInt64Value(1L))
-              .build()),
-      new StructuredTest(KnownMetrics.PRODUCER_BY_CONSUMER_REQUEST_COUNT,
-          MetricValueSet
-              .newBuilder()
-              .setMetricName(KnownMetrics.PRODUCER_BY_CONSUMER_REQUEST_COUNT.getName())
               .addMetricValues(MetricValue.newBuilder().setInt64Value(1L))
               .build()),
       new StructuredTest(KnownMetrics.CONSUMER_REQUEST_ERROR_COUNT),
@@ -112,14 +96,6 @@ public class KnownMetricsTest {
           MetricValueSet
               .newBuilder()
               .setMetricName(KnownMetrics.PRODUCER_REQUEST_ERROR_COUNT.getName())
-              .addMetricValues(MetricValue.newBuilder().setInt64Value(1L))
-              .build()),
-      new StructuredTest(KnownMetrics.PRODUCER_BY_CONSUMER_ERROR_COUNT),
-      new StructuredTest(new ReportRequestInfo().setResponseCode(400),
-          KnownMetrics.PRODUCER_BY_CONSUMER_ERROR_COUNT,
-          MetricValueSet
-              .newBuilder()
-              .setMetricName(KnownMetrics.PRODUCER_BY_CONSUMER_ERROR_COUNT.getName())
               .addMetricValues(MetricValue.newBuilder().setInt64Value(1L))
               .build()),
       };

--- a/endpoints-control/src/test/java/com/google/api/control/model/KnownMetricsTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/model/KnownMetricsTest.java
@@ -33,6 +33,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class KnownMetricsTest {
+  private static final String TEST_API_KEY = "test_key";
+
   @Test
   public void shouldBeSupported() {
     for (StructuredTest t : ALL_TESTS) {
@@ -83,7 +85,11 @@ public class KnownMetricsTest {
               .addMetricValues(MetricValue.newBuilder().setInt64Value(1L))
               .build()),
       new StructuredTest(KnownMetrics.CONSUMER_REQUEST_ERROR_COUNT),
-      new StructuredTest(new ReportRequestInfo().setResponseCode(400),
+      new StructuredTest(
+          (ReportRequestInfo) new ReportRequestInfo()
+              .setResponseCode(400)
+              .setApiKey(TEST_API_KEY)
+              .setApiKeyValid(true),
           KnownMetrics.CONSUMER_REQUEST_ERROR_COUNT,
           MetricValueSet
               .newBuilder()
@@ -91,25 +97,39 @@ public class KnownMetricsTest {
               .addMetricValues(MetricValue.newBuilder().setInt64Value(1L))
               .build()),
       new StructuredTest(KnownMetrics.PRODUCER_REQUEST_ERROR_COUNT),
-      new StructuredTest(new ReportRequestInfo().setResponseCode(400),
+      new StructuredTest(
+          (ReportRequestInfo) new ReportRequestInfo()
+              .setResponseCode(400)
+              .setApiKey(TEST_API_KEY)
+              .setApiKeyValid(true),
           KnownMetrics.PRODUCER_REQUEST_ERROR_COUNT,
           MetricValueSet
               .newBuilder()
               .setMetricName(KnownMetrics.PRODUCER_REQUEST_ERROR_COUNT.getName())
               .addMetricValues(MetricValue.newBuilder().setInt64Value(1L))
               .build()),
+      new StructuredTest(new ReportRequestInfo(), KnownMetrics.CONSUMER_REQUEST_COUNT, null),
+      new StructuredTest(new ReportRequestInfo(), KnownMetrics.CONSUMER_REQUEST_SIZES, null),
+      new StructuredTest(new ReportRequestInfo(), KnownMetrics.CONSUMER_RESPONSE_SIZES, null),
+      new StructuredTest(new ReportRequestInfo(), KnownMetrics.CONSUMER_REQUEST_ERROR_COUNT, null),
+      new StructuredTest(new ReportRequestInfo(), KnownMetrics.CONSUMER_TOTAL_LATENCIES, null),
+      new StructuredTest(new ReportRequestInfo(), KnownMetrics.CONSUMER_BACKEND_LATENCIES, null),
+      new StructuredTest(
+          new ReportRequestInfo(), KnownMetrics.CONSUMER_REQUEST_OVERHEAD_LATENCIES, null),
       };
 
   static class StructuredTest {
     StructuredTest() {
       wantedSize = 7426L; // arbitrary
-      given = new ReportRequestInfo()
+      given = (ReportRequestInfo) new ReportRequestInfo()
           .setRequestSize(wantedSize)
           .setResponseSize(wantedSize)
           .setBackendTimeMillis(wantedSize)
           .setRequestTimeMillis(wantedSize)
           .setOverheadTimeMillis(wantedSize)
-          .setResponseSize(wantedSize);
+          .setResponseSize(wantedSize)
+          .setApiKey(TEST_API_KEY)
+          .setApiKeyValid(true);
     }
 
     StructuredTest(KnownMetrics subject) {

--- a/endpoints-control/src/test/java/com/google/api/control/model/ReportRequestInfoTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/model/ReportRequestInfoTest.java
@@ -55,6 +55,7 @@ public class ReportRequestInfoTest {
   private static final String TEST_OPERATION_NAME = "anOperationName";
   private static final String TEST_OPERATION_ID = "anOperationId";
   private static final String TEST_SERVICE_NAME = "aServiceName";
+  private static final String TEST_API_KEY = "test_api_key";
   private static FakeClock TEST_CLOCK = new FakeClock();
   static {
     TEST_CLOCK.tick(2L, TimeUnit.SECONDS);
@@ -138,6 +139,7 @@ public class ReportRequestInfoTest {
   private static Operation.Builder newBaseOperation(String logName, int responseCode) {
     Operation.Builder res = Operation
         .newBuilder()
+        .setConsumerId("api_key:" + TEST_API_KEY)
         .setImportance(Importance.LOW)
         .setOperationId(TEST_OPERATION_ID)
         .setOperationName(TEST_OPERATION_NAME)
@@ -150,18 +152,21 @@ public class ReportRequestInfoTest {
   }
 
   private static ReportRequestInfo newBaseInfo() {
-    return new ReportRequestInfo(newTestOperationInfo())
+    return (ReportRequestInfo) new ReportRequestInfo(newTestOperationInfo())
         .setMethod("GET")
         .setRequestTimeMillis(TEST_LATENCY)
         .setOverheadTimeMillis(TEST_LATENCY)
         .setBackendTimeMillis(TEST_LATENCY)
         .setRequestSize(TEST_SIZE)
-        .setResponseSize(TEST_SIZE);
+        .setResponseSize(TEST_SIZE)
+        .setApiKey(TEST_API_KEY)
+        .setApiKeyValid(true);
   }
 
   private static LogEntry.Builder newTestLogEntry(String name, int responseCode) {
     Value.Builder vb = Value.newBuilder();
     Map<String, Value> values = Maps.newHashMap();
+    values.put("api_key", vb.setStringValue(TEST_API_KEY).build());
     values.put("http_method", vb.setStringValue("GET").build());
     values.put("timestamp",
         vb.setNumberValue(TEST_CLOCK.currentTimeMillis()).build());


### PR DESCRIPTION
* Remove by-consumer metrics as they're not ready
* Only send consumer metrics when a valid API key exists