### PR TITLE
add computing platform reporting

### DIFF
--- a/endpoints-control-appengine/src/main/java/com/google/api/control/extensions/appengine/GoogleAppEngineControlFilter.java
+++ b/endpoints-control-appengine/src/main/java/com/google/api/control/extensions/appengine/GoogleAppEngineControlFilter.java
@@ -17,6 +17,7 @@
 package com.google.api.control.extensions.appengine;
 
 import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.util.Clock;
 import com.google.api.control.Client;
 import com.google.api.control.ControlFilter;
@@ -36,8 +37,9 @@ import java.security.GeneralSecurityException;
  */
 public class GoogleAppEngineControlFilter extends ControlFilter {
   @VisibleForTesting
-  GoogleAppEngineControlFilter(Client client, String projectId, Ticker ticker, Clock clock) {
-    super(client, projectId, ticker, clock);
+  GoogleAppEngineControlFilter(Client client, String projectId, Ticker ticker, Clock clock,
+      HttpTransport transport) {
+    super(client, projectId, ticker, clock, UrlFetchTransport.getDefaultInstance());
   }
 
   /**

--- a/endpoints-control/src/main/java/com/google/api/control/model/KnownLabels.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/KnownLabels.java
@@ -182,9 +182,9 @@ public enum KnownLabels {
         @Override
         public void update(String name, ReportRequestInfo info, Map<String, String> labels) {
           if (info.getPlatform() != null) {
-            labels.put(name, info.getPlatform().name());
+            labels.put(name, info.getPlatform().getName());
           } else {
-            labels.put(name, ReportRequestInfo.ReportedPlatforms.UNKNOWN.name());
+            labels.put(name, ReportRequestInfo.ReportedPlatforms.UNKNOWN.getName());
           }
         }
       }),

--- a/endpoints-control/src/main/java/com/google/api/control/model/ReportRequestInfo.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/ReportRequestInfo.java
@@ -36,11 +36,27 @@ import java.util.Map;
  * and transport layers.
  */
 public class ReportRequestInfo extends OperationInfo {
+
   /**
    * ReportedPlatform enumerates the platforms that may be reported.
    */
   public enum ReportedPlatforms {
-    UNKNOWN, GAE, GCE, GKE
+    UNKNOWN("Unknown"),
+    GAE_STANDARD("GAE Standard"),
+    GAE_FLEX("GAE"),
+    GCE("GCE"),
+    GKE("GKE"),
+    DEVELOPMENT("Development");
+
+    private final String name;
+
+    ReportedPlatforms(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
   }
 
   /**


### PR DESCRIPTION
This change sets the platform label to correctly report requests coming
from within Google Cloud Platform environments. Supported are:

* Google Kubernetes Engine
* Google Compute Engine
* Google App Engine Standard
* Google App Engine Flexible Environment
* Google App Engine local development server