### PR TITLE
fix service agent and platform reporting

### DIFF
--- a/endpoints-control/build.gradle
+++ b/endpoints-control/build.gradle
@@ -41,6 +41,12 @@ sourceSets {
   }
 }
 
+processResources {
+  filesMatching('**/version.properties') {
+    expand 'serviceControlVersion': project.findProperty("version") ?: "UNKNOWN"
+  }
+}
+
 dependencies {
   compile "com.google.api.grpc:googleapis-common-protos:$googleapisCommonProtosVersion"
   compile "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"

--- a/endpoints-control/src/main/java/com/google/api/control/model/KnownLabels.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/KnownLabels.java
@@ -36,8 +36,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import com.google.rpc.Code;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * KnownLabels enumerates the well-known labels and allows them to be added to the ReportRequest's
@@ -227,7 +230,7 @@ public enum KnownLabels {
   /**
    * The service agent to record in report requests
    */
-  public static final String SERVICE_AGENT = "EF_JAVA/" + getAgentVersion();
+  public static final String SERVICE_AGENT = getServiceAgent();
 
   private String name;
   private LabelDescriptor.ValueType type;
@@ -350,8 +353,14 @@ public enum KnownLabels {
     }
   }
 
-  private static String getAgentVersion() {
-    String implVersion = KnownLabels.class.getPackage().getImplementationVersion();
-    return implVersion != null ? implVersion : "UNKNOWN";
+  private static String getServiceAgent() {
+    InputStream in = KnownLabels.class.getResourceAsStream("version.properties");
+    Properties properties = new Properties();
+    try {
+      properties.load(in);
+      return "EF_JAVA/" + properties.getProperty("version");
+    } catch (IOException e) {
+      return "EF_JAVA/UNKNOWN";
+    }
   }
 }

--- a/endpoints-control/src/main/java/com/google/api/control/model/ReportRequestInfo.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/ReportRequestInfo.java
@@ -140,6 +140,11 @@ public class ReportRequestInfo extends OperationInfo {
       for (KnownLabels l : rules.getLabels()) {
         l.performUpdate(this, addedLabels);
       }
+      // Forcibly add platform reporting here, as the base service config does not specify it as a
+      // label.
+      if (!o.getLabelsMap().containsKey(KnownLabels.SCC_PLATFORM.getName())) {
+        KnownLabels.SCC_PLATFORM.performUpdate(this, addedLabels);
+      }
       o.putAllLabels(getSystemLabels());
       o.putAllLabels(addedLabels);
       KnownMetrics[] metrics = rules.getMetrics();

--- a/endpoints-control/src/main/resources/com/google/api/control/model/version.properties
+++ b/endpoints-control/src/main/resources/com/google/api/control/model/version.properties
@@ -1,0 +1,1 @@
+version=${serviceControlVersion}

--- a/endpoints-control/src/test/java/com/google/api/control/ControlFilterTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/ControlFilterTest.java
@@ -68,6 +68,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import javax.servlet.FilterChain;
@@ -112,7 +113,7 @@ public class ControlFilterTest {
   private static final Map<String, String> OPERATION_LABELS =
       ImmutableMap.of(CheckRequestInfo.SCC_CALLER_IP, TEST_CLIENT_IP, OperationInfo.SCC_REFERER,
           REFERER, OperationInfo.SCC_USER_AGENT, "ESP", OperationInfo.SCC_SERVICE_AGENT,
-          "EF_JAVA/UNKNOWN");
+          KnownLabels.SERVICE_AGENT);
 
   @Before
   public void setUp() {
@@ -176,7 +177,8 @@ public class ControlFilterTest {
     Operation op = aReport.getOperations(0);
     Map<String, String> wantedLabels =
         ImmutableMap.of(KnownLabels.GCP_LOCATION.getName(), "global", OperationInfo.SCC_USER_AGENT,
-            "ESP", OperationInfo.SCC_SERVICE_AGENT, "EF_JAVA/UNKNOWN");
+            "ESP", OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT,
+            KnownLabels.SCC_PLATFORM.getName(), "Unknown");
     assertThat(op.getLabelsMap()).isEqualTo(wantedLabels);
     // TODO: Add more assertions
   }
@@ -224,10 +226,14 @@ public class ControlFilterTest {
     assertThat(aReport.getServiceName()).isEqualTo(TEST_SERVICE_NAME);
     Operation op = aReport.getOperations(0);
     Map<String, String> wantedLabels =
-        ImmutableMap.of(KnownLabels.RESPONSE_CODE_CLASS.getName(), "2xx",
-            KnownLabels.PROTOCOL.getName(), "HTTP", KnownLabels.REFERER.getName(), "testReferer",
-            OperationInfo.SCC_USER_AGENT, "ESP", OperationInfo.SCC_SERVICE_AGENT,
-            "EF_JAVA/UNKNOWN");
+        ImmutableMap.<String, String>builder()
+            .put(KnownLabels.RESPONSE_CODE_CLASS.getName(), "2xx")
+            .put(KnownLabels.PROTOCOL.getName(), "HTTP")
+            .put(KnownLabels.REFERER.getName(), "testReferer")
+            .put(OperationInfo.SCC_USER_AGENT, "ESP")
+            .put(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT)
+            .put(KnownLabels.SCC_PLATFORM.getName(), "Unknown")
+            .build();
     assertThat(op.getLabelsMap()).isEqualTo(wantedLabels);
     // TODO: Add more assertions
   }
@@ -260,10 +266,14 @@ public class ControlFilterTest {
       assertThat(aReport.getServiceName()).isEqualTo(TEST_SERVICE_NAME);
       Operation op = aReport.getOperations(0);
       Map<String, String> wantedLabels =
-          ImmutableMap.of(KnownLabels.RESPONSE_CODE_CLASS.getName(), "2xx",
-              KnownLabels.PROTOCOL.getName(), "HTTP", KnownLabels.REFERER.getName(), "testReferer",
-              OperationInfo.SCC_USER_AGENT, "ESP", OperationInfo.SCC_SERVICE_AGENT,
-              "EF_JAVA/UNKNOWN");
+          ImmutableMap.<String, String>builder()
+              .put(KnownLabels.RESPONSE_CODE_CLASS.getName(), "2xx")
+              .put(KnownLabels.PROTOCOL.getName(), "HTTP")
+              .put(KnownLabels.REFERER.getName(), "testReferer")
+              .put(OperationInfo.SCC_USER_AGENT, "ESP")
+              .put(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT)
+              .put(KnownLabels.SCC_PLATFORM.getName(), "Unknown")
+              .build();
       assertThat(op.getLabelsMap()).isEqualTo(wantedLabels);
       assertThat(op.getConsumerId()).isEqualTo("api_key:" + testApiKey);
       reset(client);
@@ -302,10 +312,14 @@ public class ControlFilterTest {
     assertThat(aReport.getServiceName()).isEqualTo(TEST_SERVICE_NAME);
     Operation op = aReport.getOperations(0);
     Map<String, String> wantedLabels =
-        ImmutableMap.of(KnownLabels.RESPONSE_CODE_CLASS.getName(), "4xx",
-            KnownLabels.PROTOCOL.getName(), "HTTP", KnownLabels.REFERER.getName(), "testReferer",
-            OperationInfo.SCC_USER_AGENT, "ESP", OperationInfo.SCC_SERVICE_AGENT,
-            "EF_JAVA/UNKNOWN");
+        ImmutableMap.<String, String>builder()
+            .put(KnownLabels.RESPONSE_CODE_CLASS.getName(), "4xx")
+            .put(KnownLabels.PROTOCOL.getName(), "HTTP")
+            .put(KnownLabels.REFERER.getName(), "testReferer")
+            .put(OperationInfo.SCC_USER_AGENT, "ESP")
+            .put(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT)
+            .put(KnownLabels.SCC_PLATFORM.getName(), "Unknown")
+            .build();
     assertThat(op.getLabelsMap()).isEqualTo(wantedLabels);
   }
 
@@ -346,10 +360,14 @@ public class ControlFilterTest {
     assertThat(aReport.getServiceName()).isEqualTo(TEST_SERVICE_NAME);
     Operation op = aReport.getOperations(0);
     Map<String, String> wantedLabels =
-        ImmutableMap.of(KnownLabels.RESPONSE_CODE_CLASS.getName(), "4xx",
-            KnownLabels.PROTOCOL.getName(), "HTTP", KnownLabels.REFERER.getName(), "testReferer",
-            OperationInfo.SCC_USER_AGENT, "ESP", OperationInfo.SCC_SERVICE_AGENT,
-            "EF_JAVA/UNKNOWN");
+        ImmutableMap.<String, String>builder()
+            .put(KnownLabels.RESPONSE_CODE_CLASS.getName(), "4xx")
+            .put(KnownLabels.PROTOCOL.getName(), "HTTP")
+            .put(KnownLabels.REFERER.getName(), "testReferer")
+            .put(OperationInfo.SCC_USER_AGENT, "ESP")
+            .put(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT)
+            .put(KnownLabels.SCC_PLATFORM.getName(), "Unknown")
+            .build();
     assertThat(op.getLabelsMap()).isEqualTo(wantedLabels);
 
     // confirm that the report uses a consumer id derived from the project
@@ -380,10 +398,14 @@ public class ControlFilterTest {
     assertThat(aReport.getServiceName()).isEqualTo(TEST_SERVICE_NAME);
     Operation op = aReport.getOperations(0);
     Map<String, String> wantedLabels =
-        ImmutableMap.of(KnownLabels.RESPONSE_CODE_CLASS.getName(), "2xx",
-            KnownLabels.PROTOCOL.getName(), "HTTP", KnownLabels.REFERER.getName(), "testReferer",
-            OperationInfo.SCC_USER_AGENT, "ESP", OperationInfo.SCC_SERVICE_AGENT,
-            "EF_JAVA/UNKNOWN");
+        ImmutableMap.<String, String>builder()
+            .put(KnownLabels.RESPONSE_CODE_CLASS.getName(), "2xx")
+            .put(KnownLabels.PROTOCOL.getName(), "HTTP")
+            .put(KnownLabels.REFERER.getName(), "testReferer")
+            .put(OperationInfo.SCC_USER_AGENT, "ESP")
+            .put(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT)
+            .put(KnownLabels.SCC_PLATFORM.getName(), "Unknown")
+            .build();
     assertThat(op.getLabelsMap()).isEqualTo(wantedLabels);
   }
 
@@ -417,10 +439,14 @@ public class ControlFilterTest {
     assertThat(aReport.getServiceName()).isEqualTo(TEST_SERVICE_NAME);
     Operation op = aReport.getOperations(0);
     Map<String, String> wantedLabels =
-        ImmutableMap.of(KnownLabels.RESPONSE_CODE_CLASS.getName(), "4xx",
-            KnownLabels.PROTOCOL.getName(), "HTTP", KnownLabels.REFERER.getName(), "testReferer",
-            OperationInfo.SCC_USER_AGENT, "ESP", OperationInfo.SCC_SERVICE_AGENT,
-            "EF_JAVA/UNKNOWN");
+        ImmutableMap.<String, String>builder()
+            .put(KnownLabels.RESPONSE_CODE_CLASS.getName(), "4xx")
+            .put(KnownLabels.PROTOCOL.getName(), "HTTP")
+            .put(KnownLabels.REFERER.getName(), "testReferer")
+            .put(OperationInfo.SCC_USER_AGENT, "ESP")
+            .put(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT)
+            .put(KnownLabels.SCC_PLATFORM.getName(), "Unknown")
+            .build();
     assertThat(op.getLabelsMap()).isEqualTo(wantedLabels);
   }
 
@@ -454,10 +480,14 @@ public class ControlFilterTest {
       assertThat(aReport.getServiceName()).isEqualTo(TEST_SERVICE_NAME);
       Operation op = aReport.getOperations(0);
       Map<String, String> wantedLabels =
-          ImmutableMap.of(KnownLabels.RESPONSE_CODE_CLASS.getName(), "2xx",
-              KnownLabels.PROTOCOL.getName(), "HTTP", KnownLabels.REFERER.getName(), "testReferer",
-              OperationInfo.SCC_USER_AGENT, "ESP", OperationInfo.SCC_SERVICE_AGENT,
-              "EF_JAVA/UNKNOWN");
+          ImmutableMap.<String, String>builder()
+              .put(KnownLabels.RESPONSE_CODE_CLASS.getName(), "2xx")
+              .put(KnownLabels.PROTOCOL.getName(), "HTTP")
+              .put(KnownLabels.REFERER.getName(), "testReferer")
+              .put(OperationInfo.SCC_USER_AGENT, "ESP")
+              .put(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT)
+              .put(KnownLabels.SCC_PLATFORM.getName(), "Unknown")
+              .build();
       assertThat(op.getLabelsMap()).isEqualTo(wantedLabels);
       assertThat(op.getConsumerId()).isEqualTo("api_key:" + testApiKey);
       reset(client);
@@ -469,7 +499,8 @@ public class ControlFilterTest {
   public void getPlatformFromEnvironment_Gke() {
     assertThat(
         ControlFilter.getPlatformFromEnvironment(
-            ImmutableMap.of("KUBERNETES_SERVICE_HOST", "test"), new MetadataTransport(true)))
+            ImmutableMap.of("KUBERNETES_SERVICE_HOST", "test"), new Properties(),
+            new MetadataTransport(true)))
         .isEqualTo(ReportedPlatforms.GKE);
   }
 
@@ -477,31 +508,38 @@ public class ControlFilterTest {
   public void getPlatformFromEnvironment_Gce() {
     assertThat(
         ControlFilter.getPlatformFromEnvironment(
-            ImmutableMap.<String, String>of(), new MetadataTransport(true)))
+            ImmutableMap.<String, String>of(), new Properties(), new MetadataTransport(true)))
         .isEqualTo(ReportedPlatforms.GCE);
   }
 
   @Test
   public void getPlatformFromEnvironment_GaeStandard() {
+    Properties properties = new Properties();
+    properties.setProperty("com.google.appengine.runtime.environment", "Production");
     assertThat(
         ControlFilter.getPlatformFromEnvironment(
-            ImmutableMap.of("GAE_MODULE_NAME", "test"), new MetadataTransport(false)))
+            ImmutableMap.of("GAE_MODULE_NAME", "test"), properties, new MetadataTransport(false)))
         .isEqualTo(ReportedPlatforms.GAE_STANDARD);
   }
 
   @Test
   public void getPlatformFromEnvironment_GaeFlex() {
+    Properties properties = new Properties();
+    properties.setProperty("com.google.appengine.runtime.environment", "Production");
     assertThat(
         ControlFilter.getPlatformFromEnvironment(
-            ImmutableMap.of("GAE_MODULE_NAME", "test"), new MetadataTransport(true)))
+            ImmutableMap.of("GAE_MODULE_NAME", "test"), properties, new MetadataTransport(true)))
         .isEqualTo(ReportedPlatforms.GAE_FLEX);
   }
 
   @Test
   public void getPlatformFromEnvironment_Development() {
+    Properties properties = new Properties();
+    properties.setProperty("com.google.appengine.runtime.environment", "Development");
     assertThat(
         ControlFilter.getPlatformFromEnvironment(
-            ImmutableMap.of("SERVER_SOFTWARE", "Development"), new MetadataTransport(false)))
+            ImmutableMap.of("SERVER_SOFTWARE", "Development"), properties,
+            new MetadataTransport(false)))
         .isEqualTo(ReportedPlatforms.DEVELOPMENT);
   }
 
@@ -509,7 +547,7 @@ public class ControlFilterTest {
   public void getPlatformFromEnvironment_Unknown() {
     assertThat(
         ControlFilter.getPlatformFromEnvironment(
-            ImmutableMap.<String, String>of(), new MetadataTransport(false)))
+            ImmutableMap.<String, String>of(), new Properties(), new MetadataTransport(false)))
         .isEqualTo(ReportedPlatforms.UNKNOWN);
   }
 

--- a/endpoints-control/src/test/java/com/google/api/control/model/CheckRequestInfoTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/model/CheckRequestInfoTest.java
@@ -117,7 +117,7 @@ public class CheckRequestInfoTest {
         .setEndTime(REALLY_EARLY)
         .setStartTime(REALLY_EARLY)
         .putLabels(OperationInfo.SCC_USER_AGENT, "ESP")
-        .putLabels(OperationInfo.SCC_SERVICE_AGENT, "EF_JAVA/UNKNOWN");
+        .putLabels(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT);
   }
 
   private static OperationInfo newTestOperationInfo() {

--- a/endpoints-control/src/test/java/com/google/api/control/model/ReportRequestInfoTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/model/ReportRequestInfoTest.java
@@ -148,7 +148,8 @@ public class ReportRequestInfoTest {
         .setEndTime(REALLY_EARLY)
         .setStartTime(REALLY_EARLY)
         .putLabels(OperationInfo.SCC_USER_AGENT, "ESP")
-        .putLabels(OperationInfo.SCC_SERVICE_AGENT, "EF_JAVA/UNKNOWN");
+        .putLabels(OperationInfo.SCC_SERVICE_AGENT, KnownLabels.SERVICE_AGENT)
+        .putLabels(KnownLabels.SCC_PLATFORM.getName(), "Unknown");
     if (!Strings.isNullOrEmpty(logName)) {
       res.addLogEntries(newTestLogEntry(logName, responseCode));
     }


### PR DESCRIPTION
* Instead of depending on the JAR implementation version, use a JAR
  properties file to store the version. This is more reliable and works
  in tests as well. The properties file automatically inherits the
  version number according to Gradle at compile time.
* Use system properties for detecting App Engine. The environment
  variable method seems to only work for Python.
* Forcibly include platform reporting. By default, it isn't included,
  because the base service config doesn't add it as a label.