### PR TITLE
cleanup dependencies

### DIFF
--- a/endpoints-framework-auth/build.gradle
+++ b/endpoints-framework-auth/build.gradle
@@ -22,10 +22,11 @@ configureMaven(
 archivesBaseName = "endpoints-framework-auth"
 
 dependencies {
-  compile group: "com.google.endpoints", name: "endpoints-framework", version: "2.0.0-beta.2"
+  compileOnly group: "com.google.endpoints", name: "endpoints-framework", version: "${endpointsFrameworkVersion}"
   compile project(":endpoints-auth")
 
   testCompile group: "junit", name: "junit", version: "${junitVersion}"
   testCompile group: "org.mockito", name: "mockito-core", version: "${mockitoVersion}"
   testCompile group: "org.springframework", name: "spring-test", version: "${springTestVersion}"
+  testCompile group: "com.google.endpoints", name: "endpoints-framework", version: "${endpointsFrameworkVersion}"
 }

--- a/endpoints-management-protos/build.gradle
+++ b/endpoints-management-protos/build.gradle
@@ -23,7 +23,6 @@ repositories {
 dependencies {
   compile "com.google.protobuf:protobuf-java:3.0.0"
   compile "com.google.api.grpc:googleapis-common-protos:0.0.2"
-  compile "io.grpc:grpc-all:0.15.0"
 }
 
 protobuf {

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,7 @@ protobufUtilVersion = 3.0.0-beta-4
 servicemanagementVersion = v1-rev14-1.22.0
 servletApiVersion = 2.5
 truthVersion = 0.27
+endpointsFrameworkVersion = 2.0.1
 
 mockitoVersion = 2.0.90-beta
 junitVersion = 4.12


### PR DESCRIPTION
* There was an unnecessary dependency on grpc, which has been removed.
* The endpoints-framework dependency has been made compile only to
  prevent multiple copies of the framework from being included in the
  web app.