### PR TITLE
change Flex platform from GAE to GAE Flex

### DIFF
--- a/endpoints-control/src/main/java/com/google/api/control/model/ReportRequestInfo.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/ReportRequestInfo.java
@@ -43,7 +43,7 @@ public class ReportRequestInfo extends OperationInfo {
   public enum ReportedPlatforms {
     UNKNOWN("Unknown"),
     GAE_STANDARD("GAE Standard"),
-    GAE_FLEX("GAE"),
+    GAE_FLEX("GAE Flex"),
     GCE("GCE"),
     GKE("GKE"),
     DEVELOPMENT("Development");


### PR DESCRIPTION
This matches a change made awhile ago in the Endpoints Server Proxy.