### PR TITLE
ignore trailing slashes on path matching

### DIFF
--- a/endpoints-control/src/main/java/com/google/api/control/model/MethodRegistry.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/MethodRegistry.java
@@ -24,6 +24,7 @@ import com.google.api.Service;
 import com.google.api.SystemParameter;
 import com.google.api.SystemParameterRule;
 import com.google.api.UsageRule;
+import com.google.api.control.util.StringUtils;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -85,6 +86,7 @@ public class MethodRegistry {
     if (url.startsWith("/")) {
       url = url.substring(1);
     }
+    url = StringUtils.stripTrailingSlash(url);
     List<Info> infos = infosByHttpMethod.get(httpMethod);
     if (infos == null) {
       log.log(Level.FINE,
@@ -113,7 +115,7 @@ public class MethodRegistry {
     Set<String> allUrls = Sets.newHashSet();
     Set<String> urlsWithOptions = Sets.newHashSet();
     for (HttpRule r : rules) {
-      String url = urlFrom(r);
+      String url = StringUtils.stripTrailingSlash(urlFrom(r));
       String httpMethod = httpMethodFrom(r);
       if (Strings.isNullOrEmpty(url) || Strings.isNullOrEmpty(httpMethod)
           || Strings.isNullOrEmpty(r.getSelector())) {

--- a/endpoints-control/src/main/java/com/google/api/control/util/StringUtils.java
+++ b/endpoints-control/src/main/java/com/google/api/control/util/StringUtils.java
@@ -1,0 +1,18 @@
+package com.google.api.control.util;
+
+import com.google.common.base.CharMatcher;
+
+/**
+ * String utilities.
+ */
+public final class StringUtils {
+  /**
+   * Strips the trailing slash from a string if it has a trailing slash; otherwise return the
+   * string unchanged.
+   */
+  public static String stripTrailingSlash(String s) {
+    return s == null ? null : CharMatcher.is('/').trimTrailingFrom(s);
+  }
+
+  private StringUtils() { }
+}

--- a/endpoints-control/src/test/java/com/google/api/control/model/MethodRegistryTest.java
+++ b/endpoints-control/src/test/java/com/google/api/control/model/MethodRegistryTest.java
@@ -1,0 +1,51 @@
+package com.google.api.control.model;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.Http;
+import com.google.api.HttpRule;
+import com.google.api.Service;
+import com.google.api.control.model.MethodRegistry.Info;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link MethodRegistry}.
+ */
+public class MethodRegistryTest {
+  private static final String SELECTOR = "a.selector";
+  private static final String SLASH_SELECTOR = "slash.selector";
+  private static final Service SERVICE = Service.newBuilder()
+      .setName("the-service")
+      .setHttp(Http.newBuilder()
+          .addRules(HttpRule.newBuilder()
+              .setSelector(SELECTOR)
+              .setGet("/v1/foo/{bar}/baz"))
+          .addRules(HttpRule.newBuilder()
+              .setSelector(SLASH_SELECTOR)
+              .setGet("/v1/baz/{bar}/foo/")))
+      .build();
+
+  @Test
+  public void lookup_matchesWithOrWithoutTrailingSlashes() {
+    MethodRegistry r = new MethodRegistry(SERVICE);
+    assertSuccess(r.lookup("GET", "/v1/foo/2/baz"), SELECTOR);
+    assertSuccess(r.lookup("GET", "/v1/foo/2/baz/"), SELECTOR);
+    assertFailure(r.lookup("POST", "/v1/foo/2/baz"));
+    assertFailure(r.lookup("POST", "/v1/foo/2/baz/"));
+
+    assertSuccess(r.lookup("GET", "/v1/baz/2/foo"), SLASH_SELECTOR);
+    assertSuccess(r.lookup("GET", "/v1/baz/2/foo/"), SLASH_SELECTOR);
+    assertFailure(r.lookup("POST", "/v1/baz/2/foo"));
+    assertFailure(r.lookup("POST", "/v1/baz/2/foo/"));
+  }
+
+  private static void assertFailure(Info info) {
+    assertThat(info).isNull();
+  }
+
+  private static void assertSuccess(Info info, String selector) {
+    assertThat(info).isNotNull();
+    assertThat(info.getSelector()).isEqualTo(selector);
+  }
+}


### PR DESCRIPTION
MethodRegistry now stores paths without trailing slashes. During
lookup, the request URL is also stripped of trailing slashes. This
fixes an issue where control fails open due to a trailing slash not
matching an API method, but the Endpoints Framework processing it, due
to correct handling of trailing slashes. This should prevent leaks
through the control filter.