### PR TITLE
add better error handling for config filter init

### DIFF
--- a/endpoints-service-config/build.gradle
+++ b/endpoints-service-config/build.gradle
@@ -32,4 +32,5 @@ dependencies {
 
   testCompile "org.mockito:mockito-core:$mockitoVersion"
   testCompile "junit:junit:$junitVersion"
+  testCompile "com.google.truth:truth:$truthVersion"
 }

--- a/endpoints-service-config/src/test/java/com/google/api/config/ServiceConfigSupplierTest.java
+++ b/endpoints-service-config/src/test/java/com/google/api/config/ServiceConfigSupplierTest.java
@@ -16,6 +16,7 @@
 
 package com.google.api.config;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -149,7 +150,8 @@ public final class ServiceConfigSupplierTest {
       fetcher.get();
       fail();
     } catch (ServiceConfigException exception) {
-      assertEquals("Failed to fetch service config (status code 404)", exception.getMessage());
+      assertThat(exception.getMessage())
+          .startsWith("Failed to fetch service config (status code 404):");
     }
   }
 


### PR DESCRIPTION
Right now, if the service config fetching fails, it crashes the
instance due to throwing a RuntimeException, while the filter
initialization catches only IOException. This change will also catch
ServiceConfigException.

Current ESP behavior is to crash the instance if service config
fetching fails; however, this behavior is not as desirable, especially
from App Engine, which will aggressively and quickly retry
initialization, which can potentially exhaust quota. Thus, this change
will log the error, but allow initialization to continue, but deny all
requests that pass through the filter to ensure that the API is not
unduly accessible.

Lastly, this change adds some extensive help text to a few specific
error codes that the Service Management API may return, to help user
debugging.