### PR TITLE
migrate all logging to flogger

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -164,11 +164,11 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         -->
-        <module name="CustomImportOrder">
+        <!--<module name="CustomImportOrder">
             <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
-        </module>
+        </module>-->
 	<module name="IllegalImport">
             <property name="illegalPkgs" value="autovalue.shaded"/>
             <property name="illegalPkgs" value="com.google.api.client.repackaged"/>

--- a/endpoints-auth/build.gradle
+++ b/endpoints-auth/build.gradle
@@ -35,6 +35,8 @@ dependencies {
   compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
   compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
   compile "com.google.guava:guava:${guavaVersion}"
+  compile "com.google.flogger:flogger:${floggerVersion}"
+  runtime "com.google.flogger:flogger-system-backend:${floggerVersion}"
   compile "com.google.http-client:google-http-client:${httpClientVersion}"
   compile "javax.servlet:servlet-api:${servletApiVersion}"
   compile "org.bitbucket.b_c:jose4j:${jose4jVersion}"

--- a/endpoints-auth/src/main/java/com/google/api/auth/Authenticator.java
+++ b/endpoints-auth/src/main/java/com/google/api/auth/Authenticator.java
@@ -32,19 +32,16 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import com.google.common.flogger.FluentLogger;
 import com.google.common.net.HttpHeaders;
-
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.NumericDate;
 import org.jose4j.jwt.ReservedClaimNames;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
-
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * An authenticator that extracts the auth token from the HTTP request and
@@ -56,7 +53,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class Authenticator {
 
-  private static final Logger logger = Logger.getLogger(Authenticator.class.getName());
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static final String ACCESS_TOKEN_PARAM_NAME = "access_token";
   private static final String BEARER_TOKEN_PREFIX = "Bearer ";
@@ -207,8 +204,7 @@ public class Authenticator {
     for (AuthProvider authProvider : authProviders) {
       String issuer = authProvider.getIssuer();
       if (Strings.isNullOrEmpty(issuer)) {
-        logger.warning(
-            String.format("The 'issuer' field is not set in AuthProvider (%s)", authProvider));
+        logger.atWarning().log("The 'issuer' field is not set in AuthProvider (%s)", authProvider);
         continue;
       }
 

--- a/endpoints-control/build.gradle
+++ b/endpoints-control/build.gradle
@@ -51,6 +51,8 @@ dependencies {
   compileOnly "com.google.auto.value:auto-value:${autoValueVersion}"
   compile "com.google.code.findbugs:jsr305:${jsr305Version}"
   compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+  compile "com.google.flogger:flogger:${floggerVersion}"
+  runtime "com.google.flogger:flogger-system-backend:${floggerVersion}"
   compile "com.google.guava:guava:${guavaVersion}"
   compile("com.google.http-client:google-http-client-jackson2:${httpClientVersion}") {
     exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'

--- a/endpoints-control/src/main/java/com/google/api/control/ControlFilter.java
+++ b/endpoints-control/src/main/java/com/google/api/control/ControlFilter.java
@@ -44,8 +44,8 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.FluentLogger;
 import com.google.common.io.CountingOutputStream;
-
 import java.io.BufferedWriter;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -60,9 +60,6 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -83,7 +80,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
  * 'reported' via a call to {@link Client#report(com.google.api.servicecontrol.v1.ReportRequest)}
  */
 public class ControlFilter implements Filter {
-  private static final Logger log = Logger.getLogger(ControlFilter.class.getName());
+  private static final FluentLogger log = FluentLogger.forEnclosingClass();
   private static final String REFERER = "referer";
   private static final String PROJECT_ID_PARAM = "endpoints.projectId";
   private static final String SERVICE_NAME_PARAM = "endpoints.serviceName";
@@ -133,10 +130,10 @@ public class ControlFilter implements Filter {
     try {
       if (!Strings.isNullOrEmpty(statsFrequencyText)) {
         statsLogFrequency = Integer.parseInt(statsFrequencyText);
-        log.log(Level.WARNING, String.format("will log stats every %d reports", statsLogFrequency));
+        log.atWarning().log("will log stats every %d reports", statsLogFrequency);
       }
     } catch (NumberFormatException e) {
-      log.log(Level.WARNING, String.format("ignored invalid debug stat value %s", statsFrequencyText));
+      log.atWarning().log("ignored invalid debug stat value %s", statsFrequencyText);
     }
 
     String configServiceName = filterConfig.getInitParameter(SERVICE_NAME_PARAM);
@@ -145,9 +142,9 @@ public class ControlFilter implements Filter {
         this.client = createClient(configServiceName);
         this.client.start();
       } catch (GeneralSecurityException e) {
-        log.log(Level.SEVERE, "could not create the control client", e);
+        log.atSevere().withCause(e).log("could not create the control client");
       } catch (IOException e) {
-        log.log(Level.SEVERE, "could not create the control client", e);
+        log.atSevere().withCause(e).log("could not create the control client");
       }
     }
   }
@@ -203,13 +200,12 @@ public class ControlFilter implements Filter {
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
     if (client == null) {
-      log.log(Level.INFO,
-          String.format("No control client was created - skipping service control"));
+      log.atInfo().log("No control client was created - skipping service control");
       chain.doFilter(request, response);
       return;
     }
     if (projectId == null) {
-      log.log(Level.INFO, String.format("No project Id was specified - skipping service control"));
+      log.atInfo().log("No project Id was specified - skipping service control");
       chain.doFilter(request, response);
       return;
     }
@@ -222,10 +218,8 @@ public class ControlFilter implements Filter {
     MethodRegistry.Info info = ConfigFilter.getMethodInfo(request);
     HttpServletRequest httpRequest = (HttpServletRequest) request;
     if (info == null) {
-      if (log.isLoggable(Level.FINE)) {
-        log.log(Level.FINE, String.format("no method corresponds to %s - skipping service control",
-            httpRequest.getRequestURI()));
-      }
+      log.atFine().log(
+          "no method corresponds to %s - skipping service control", httpRequest.getRequestURI());
       chain.doFilter(request, response);
       return;
     }
@@ -245,17 +239,13 @@ public class ControlFilter implements Filter {
     long consumerProjectNumber = 0;
     if (Strings.isNullOrEmpty(checkInfo.getApiKey()) && !info.shouldAllowUnregisteredCalls()) {
       errorInfo = CheckErrorInfo.API_KEY_NOT_PROVIDED;
-      if (log.isLoggable(Level.FINE)) {
-        log.log(Level.FINE, "no api key was provided");
-      }
+      log.atFine().log("no api key was provided");
     } else {
       creationTimer.reset().start();
       CheckRequest checkRequest = checkInfo.asCheckRequest(clock);
       statistics.totalChecks.incrementAndGet();
       statistics.totalCheckCreationTime.addAndGet(creationTimer.elapsed(TimeUnit.MILLISECONDS));
-      if (log.isLoggable(Level.FINE)) {
-        log.log(Level.FINE, String.format("checking using %s", checkRequest));
-      }
+      log.atFine().log("checking using %s", checkRequest);
       checkResponse = client.check(checkRequest);
       errorInfo = CheckErrorInfo.convert(checkResponse);
       if (checkResponse != null) {
@@ -266,8 +256,7 @@ public class ControlFilter implements Filter {
     // Handle check failures. This includes check transport failures, in
     // which case the checkResponse is null.
     if (errorInfo != CheckErrorInfo.OK) {
-      log.log(Level.WARNING,
-          String.format("the check did not succeed; the response %s", checkResponse));
+      log.atWarning().log("the check did not succeed; the response %s", checkResponse);
 
       // ensure the report request is created with updated api_key validity, as this determines
       // the consumer id
@@ -299,9 +288,7 @@ public class ControlFilter implements Filter {
         ReportRequest reportRequest =
             createReportRequest(info, checkInfo, appInfo, ConfigFilter.getReportRule(request),
                 timer, consumerProjectNumber);
-        if (log.isLoggable(Level.FINEST)) {
-          log.log(Level.FINEST, String.format("sending an error report request %s", reportRequest));
-        }
+        log.atFinest().log("sending an error report request %s", reportRequest);
         client.report(reportRequest);
         statistics.totalFiltered.incrementAndGet();
         statistics.totalFilteredTime.addAndGet(overallTimer.elapsed(TimeUnit.MILLISECONDS));
@@ -312,7 +299,7 @@ public class ControlFilter implements Filter {
 
     QuotaRequestInfo quotaInfo = createQuotaInfo(httpRequest, info);
     if (quotaInfo.getMetricCosts().isEmpty()) {
-      log.log(Level.FINE, "no metric costs for this method");
+      log.atFine().log("no metric costs for this method");
     } else {
       AllocateQuotaRequest quotaRequest = quotaInfo.asQuotaRequest(clock);
       AllocateQuotaResponse quotaResponse = client.allocateQuota(quotaRequest);
@@ -344,9 +331,7 @@ public class ControlFilter implements Filter {
             consumerProjectNumber);
     statistics.totalReports.incrementAndGet();
     statistics.totalReportCreationTime.addAndGet(creationTimer.elapsed(TimeUnit.MILLISECONDS));
-    if (log.isLoggable(Level.FINEST)) {
-      log.log(Level.FINEST, String.format("sending a report request %s", reportRequest));
-    }
+    log.atFinest().log("sending a report request %s", reportRequest);
     client.report(reportRequest);
     statistics.totalFiltered.incrementAndGet();
     statistics.totalFilteredTime.addAndGet(overallTimer.elapsed(TimeUnit.MILLISECONDS));
@@ -470,7 +455,7 @@ public class ControlFilter implements Filter {
       return;
     }
     if (statistics.totalFiltered.get() % statsLogFrequency == 0) {
-      log.info(statistics.toString());
+      log.atInfo().log(statistics.toString());
     }
   }
 
@@ -671,8 +656,8 @@ public class ControlFilter implements Filter {
         try {
           writer = new OutputStreamWriter(getOutputStream(), getCharacterEncoding());
         } catch (UnsupportedEncodingException e) {
-          log.warning(String.format("Could not write using charset %s, using default instead",
-              getCharacterEncoding()));
+          log.atWarning().log(
+              "Could not write using charset %s, using default instead", getCharacterEncoding());
           writer = new OutputStreamWriter(getOutputStream());
         }
         newWriter = new PrintWriter(new BufferedWriter(writer), true);

--- a/endpoints-control/src/main/java/com/google/api/control/aggregator/CheckRequestAggregator.java
+++ b/endpoints-control/src/main/java/com/google/api/control/aggregator/CheckRequestAggregator.java
@@ -28,16 +28,14 @@ import com.google.common.base.Strings;
 import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.collect.Lists;
+import com.google.common.flogger.FluentLogger;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
 
 /**
@@ -52,7 +50,7 @@ public class CheckRequestAggregator {
 
   private static final int NANOS_PER_MILLI = 1000000;
   private static final CheckRequest[] NO_REQUESTS = new CheckRequest[] {};
-  private static final Logger log = Logger.getLogger(CheckRequestAggregator.class.getName());
+  private static final FluentLogger log = FluentLogger.forEnclosingClass();
 
   private final String serviceName;
   private final CheckAggregationOptions options;
@@ -254,7 +252,7 @@ public class CheckRequestAggregator {
       }
       item.updateRequest(req, kinds);
       if (item.isFlushing) {
-        log.warning("latest check request has not completed");
+        log.atWarning().log("latest check request has not completed");
       }
 
       // Not current

--- a/endpoints-control/src/main/java/com/google/api/control/aggregator/QuotaOperationAggregator.java
+++ b/endpoints-control/src/main/java/com/google/api/control/aggregator/QuotaOperationAggregator.java
@@ -22,16 +22,14 @@ import com.google.api.servicecontrol.v1.MetricValue;
 import com.google.api.servicecontrol.v1.MetricValueSet;
 import com.google.api.servicecontrol.v1.QuotaOperation;
 import com.google.common.collect.Maps;
-
+import com.google.common.flogger.FluentLogger;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Created by tangd on 5/22/17.
  */
 public class QuotaOperationAggregator {
-  private static final Logger log = Logger.getLogger(QuotaOperationAggregator.class.getName());
+  private static final FluentLogger log = FluentLogger.forEnclosingClass();
   private QuotaOperation.Builder op;
   private Map<String, MetricValue> metricValueSets;
 
@@ -66,8 +64,7 @@ public class QuotaOperationAggregator {
 
   private MetricValue mergeDeltaMetricValue(MetricValue from, MetricValue to) {
     if (to.getValueCase() != from.getValueCase()) {
-      log.log(Level.WARNING, "Could not merge different types of metric: {0}, {1}",
-          new Object[] {from, to});
+      log.atWarning().log("Could not merge different types of metric: %s, %s", from, to);
       return to;
     }
 
@@ -92,7 +89,7 @@ public class QuotaOperationAggregator {
         builder.setInt64Value(to.getInt64Value() + from.getInt64Value());
         break;
       default:
-        log.log(Level.WARNING, "Unknown metric kind for: {0}", new Object[]{from});
+        log.atWarning().log("Unknown metric kind for: %s", from);
         break;
     }
     return builder.build();

--- a/endpoints-control/src/main/java/com/google/api/control/aggregator/QuotaRequestAggregator.java
+++ b/endpoints-control/src/main/java/com/google/api/control/aggregator/QuotaRequestAggregator.java
@@ -33,15 +33,12 @@ import com.google.common.collect.Ordering;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
 
 /**
@@ -49,7 +46,6 @@ import javax.annotation.Nullable;
  */
 
 public class QuotaRequestAggregator {
-  private static final Logger log = Logger.getLogger(QuotaRequestAggregator.class.getName());
   public static final int NON_CACHING = -1;
   private static final long NANOS_PER_MILLI = 1000000;
   private final ConcurrentLinkedDeque<AllocateQuotaRequest> out;

--- a/endpoints-control/src/main/java/com/google/api/control/model/Distributions.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/Distributions.java
@@ -23,14 +23,12 @@ import com.google.api.servicecontrol.v1.Distribution.ExplicitBuckets;
 import com.google.api.servicecontrol.v1.Distribution.ExponentialBuckets;
 import com.google.api.servicecontrol.v1.Distribution.LinearBuckets;
 import com.google.common.collect.Sets;
+import com.google.common.flogger.FluentLogger;
 import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Doubles;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Utility methods for working with {@link Distribution} instances.
@@ -46,7 +44,7 @@ public final class Distributions {
   private static final String MSG_DOUBLE_TOO_LOW = "%s should be > %f";
   private static final String MSG_BAD_NUM_FINITE_BUCKETS = "number of finite buckets should be > 0";
   private static final double TOLERANCE = 1e-5;
-  private static final Logger log = Logger.getLogger(Distributions.class.getName());
+  private static final FluentLogger log = FluentLogger.forEnclosingClass();
 
   private Distributions() {}
 
@@ -277,8 +275,7 @@ public final class Distributions {
       index = 1 + ((int) Math.round((value - buckets.getOffset()) / buckets.getWidth()));
     }
     long newCount = distribution.getBucketCounts(index) + 1;
-    log.log(Level.FINE, "Updating explicit bucket {0} to {1} for {2}",
-        new Object[] {index, newCount, value});
+    log.atFine().log("Updating explicit bucket %d to %d for %f", index, newCount, value);
     distribution.setBucketCounts(index, newCount);
   }
 
@@ -296,10 +293,7 @@ public final class Distributions {
       index = Math.min(buckets.getNumFiniteBuckets() + 1, index);
     }
     long newCount = distribution.getBucketCounts(index) + 1;
-    if (log.isLoggable(Level.FINE)) {
-      log.log(Level.FINE, "Updating explicit bucket {0} to {1} for {2}",
-          new Object[] {index, newCount, value});
-    }
+    log.atFine().log("Updating explicit bucket %d to %d for %f", index, newCount, value);
     distribution.setBucketCounts(index, newCount);
   }
 
@@ -320,10 +314,7 @@ public final class Distributions {
       index += 1;
     }
     long newCount = distribution.getBucketCounts(index) + 1;
-    if (log.isLoggable(Level.FINE)) {
-      log.log(Level.FINE, "Updating explicit bucket {0} to {1} for {2}",
-          new Object[] {index, newCount, value});
-    }
+    log.atFine().log("Updating explicit bucket %d to %d for %f", index, newCount, value);
     distribution.setBucketCounts(index, newCount);
   }
 }

--- a/endpoints-control/src/main/java/com/google/api/control/model/MethodRegistry.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/MethodRegistry.java
@@ -35,14 +35,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
+import com.google.common.flogger.FluentLogger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
@@ -50,7 +47,7 @@ import javax.annotation.Nullable;
  * MethodRegistry provides registry of the API methods defined by a Service.
  */
 public class MethodRegistry {
-  private static final Logger log = Logger.getLogger(MethodRegistry.class.getName());
+  private static final FluentLogger log = FluentLogger.forEnclosingClass();
   private static final String OPTIONS_VERB = "OPTIONS";
   private final Service theService;
   private final Map<String, AuthInfo> authInfos;
@@ -89,17 +86,17 @@ public class MethodRegistry {
     url = StringUtils.stripTrailingSlash(url);
     List<Info> infos = infosByHttpMethod.get(httpMethod);
     if (infos == null) {
-      log.log(Level.FINE,
-          String.format("no information about any urls for HTTP method %s when checking %s", httpMethod, url));
+      log.atFine().log(
+          "no information about any urls for HTTP method %s when checking %s", httpMethod, url);
       return null;
     }
     for (Info info : infos) {
-      log.log(Level.FINE, String.format("trying %s with template %s", url, info.getTemplate()));
+      log.atFine().log("trying %s with template %s", url, info.getTemplate());
       if (info.getTemplate().matches(url)) {
-        log.log(Level.FINE, String.format("%s matched %s", url, info.getTemplate()));
+        log.atFine().log("%s matched %s", url, info.getTemplate());
         return info;
       } else {
-        log.log(Level.FINE, String.format("%s did not matched %s", url, info.getTemplate()));
+        log.atFine().log("%s did not matched %s", url, info.getTemplate());
       }
     }
 
@@ -119,7 +116,7 @@ public class MethodRegistry {
       String httpMethod = httpMethodFrom(r);
       if (Strings.isNullOrEmpty(url) || Strings.isNullOrEmpty(httpMethod)
           || Strings.isNullOrEmpty(r.getSelector())) {
-        log.log(Level.WARNING, "invalid HTTP binding detected");
+        log.atWarning().log("invalid HTTP binding detected");
         continue;
       }
       Info theMethod = getOrCreateInfo(r.getSelector());
@@ -150,11 +147,10 @@ public class MethodRegistry {
         infosByHttpMethod.put(httpMethod.toLowerCase(), infos);
       }
       infos.add(theMethod);
-      log.log(Level.FINE,
-          String.format("registered template %s under method %s", t, httpMethod));
+      log.atFine().log("registered template %s under method %s", t, httpMethod);
       return true;
     } catch (ValidationException e) {
-      log.log(Level.WARNING, String.format("invalid HTTP template %s provided", url));
+      log.atWarning().log("invalid HTTP template %s provided", url);
       return false;
     }
   }
@@ -187,13 +183,11 @@ public class MethodRegistry {
     for (SystemParameterRule r : theService.getSystemParameters().getRulesList()) {
       Info info = extractedMethods.get(r.getSelector());
       if (info == null) {
-        log.log(Level.WARNING,
-            String.format("bad system parameter: no HTTP rule for %s", r.getSelector()));
+        log.atWarning().log("bad system parameter: no HTTP rule for %s", r.getSelector());
       } else {
         for (SystemParameter parameter : r.getParametersList()) {
           if (Strings.isNullOrEmpty(parameter.getName())) {
-            log.log(Level.WARNING,
-                String.format("bad system parameter: no parameter name for %s", r.getSelector()));
+            log.atWarning().log("bad system parameter: no parameter name for %s", r.getSelector());
             continue;
           }
           if (!Strings.isNullOrEmpty(parameter.getHttpHeader())) {
@@ -215,8 +209,7 @@ public class MethodRegistry {
     for (UsageRule r : theService.getUsage().getRulesList()) {
       Info info = extractedMethods.get(r.getSelector());
       if (info == null) {
-        log.log(Level.WARNING,
-            String.format("bad usage selector: no HTTP rule for %s", r.getSelector()));
+        log.atWarning().log("bad usage selector: no HTTP rule for %s", r.getSelector());
       } else {
         info.setAllowUnregisteredCalls(r.getAllowUnregisteredCalls());
       }

--- a/endpoints-control/src/main/java/com/google/api/control/model/ReportingRule.java
+++ b/endpoints-control/src/main/java/com/google/api/control/model/ReportingRule.java
@@ -26,21 +26,18 @@ import com.google.api.Monitoring.MonitoringDestination;
 import com.google.api.Service;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
+import com.google.common.flogger.FluentLogger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
 
 /**
  * ReportingRule determines how to fill a report request.
  */
 public class ReportingRule {
-  private static final Logger log = Logger.getLogger(ReportingRule.class.getName());
+  private static final FluentLogger log = FluentLogger.forEnclosingClass();
 
   /**
    * MetricSupporter defines a method that determines is a metric is supported
@@ -94,15 +91,16 @@ public class ReportingRule {
    */
   public static ReportingRule fromKnownInputs(@Nullable String[] logs,
       @Nullable Set<String> metricNames, @Nullable Set<String> labelNames) {
-    log.fine(String.format("creating rule from log names %s, metric names %s, labelNames %s",
-        Arrays.toString(logs), metricNames, labelNames));
+    log.atFine().log(
+        "creating rule from log names %s, metric names %s, labelNames %s",
+        Arrays.toString(logs), metricNames, labelNames);
     Map<String, KnownMetrics> namedRuleMetrics = Maps.newHashMap();
     if (metricNames != null) {
       for (KnownMetrics m : KnownMetrics.values()) {
         if (m.getUpdater() == null || !metricNames.contains(m.getName())) {
           continue;
         }
-        log.fine(String.format("Adding metric named '%s' to the rule", m.getName()));
+        log.atFine().log("Adding metric named '%s' to the rule", m.getName());
         namedRuleMetrics.put(m.getName(), m);
       }
     }
@@ -112,7 +110,7 @@ public class ReportingRule {
         if (k.getUpdater() == null || !labelNames.contains(k.getName())) {
           continue;
         }
-        log.fine(String.format("Adding label named '%s' to the rule", k.getName()));
+        log.atFine().log("Adding label named '%s' to the rule", k.getName());
         namedRuleLabels.put(k.getName(), k);
       }
     }
@@ -247,8 +245,7 @@ public class ReportingRule {
     for (LabelDescriptor d : labelDescs) {
       LabelDescriptor existing = labels.get(d.getKey());
       if (existing != null && !existing.getValueType().equals(d.getValueType())) {
-        log.log(Level.WARNING,
-            String.format("halted label scan: conflicting label in %s", d.getKey()));
+        log.atWarning().log("halted label scan: conflicting label in %s", d.getKey());
         return false;
       }
     }
@@ -267,7 +264,7 @@ public class ReportingRule {
         return addLabelsFromDescriptors(d.getLabelsList(), labels, check);
       }
     }
-    log.log(Level.WARNING, String.format("bad log label scan: log %s was not found", name));
+    log.atWarning().log("bad log label scan: log %s was not found", name);
     return false;
   }
 
@@ -279,8 +276,8 @@ public class ReportingRule {
         return addLabelsFromDescriptors(d.getLabelsList(), labels, check);
       }
     }
-    log.log(Level.WARNING,
-        String.format("bad monitored resource label scan: resource %s was not found", resourceType));
+    log.atWarning()
+        .log("bad monitored resource label scan: resource %s was not found", resourceType);
     return false;
   }
 

--- a/endpoints-framework-auth/build.gradle
+++ b/endpoints-framework-auth/build.gradle
@@ -29,4 +29,6 @@ dependencies {
   testCompile group: "org.mockito", name: "mockito-core", version: "${mockitoVersion}"
   testCompile group: "org.springframework", name: "spring-test", version: "${springTestVersion}"
   testCompile group: "com.google.endpoints", name: "endpoints-framework", version: "${endpointsFrameworkVersion}"
+  compile "com.google.flogger:flogger:${floggerVersion}"
+  runtime "com.google.flogger:flogger-system-backend:${floggerVersion}"
 }

--- a/endpoints-framework-auth/src/main/java/com/google/api/server/spi/auth/EspAuthenticator.java
+++ b/endpoints-framework-auth/src/main/java/com/google/api/server/spi/auth/EspAuthenticator.java
@@ -27,10 +27,8 @@ import com.google.api.server.spi.auth.common.User;
 import com.google.api.server.spi.config.Singleton;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
+import com.google.common.flogger.FluentLogger;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-
-import java.util.logging.Logger;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -46,7 +44,7 @@ import javax.servlet.http.HttpServletRequest;
 @Singleton
 public final class EspAuthenticator implements com.google.api.server.spi.config.Authenticator {
 
-  private static final Logger logger = Logger.getLogger(EspAuthenticator.class.getName());
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private final Authenticator authenticator;
 
@@ -68,7 +66,7 @@ public final class EspAuthenticator implements com.google.api.server.spi.config.
     }
     Optional<AuthInfo> authInfo = methodInfo.getAuthInfo();
     if (!authInfo.isPresent()) {
-      logger.info("auth is not configured for this request");
+      logger.atInfo().log("auth is not configured for this request");
       return null;
     }
 
@@ -83,7 +81,7 @@ public final class EspAuthenticator implements com.google.api.server.spi.config.
       UserInfo userInfo = this.authenticator.authenticate(request, authInfo.get(), serviceName);
       return new User(userInfo.getId(), userInfo.getEmail());
     } catch (UnauthenticatedException | UncheckedExecutionException exception) {
-      logger.warning(String.format("Authentication failed: %s", exception));
+      logger.atWarning().withCause(exception).log("Authentication failed");
       return null;
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,6 +38,7 @@ servicemanagementVersion = v1-rev14-1.22.0
 servletApiVersion = 2.5
 truthVersion = 0.27
 endpointsFrameworkVersion = 2.0.1
+floggerVersion=0.3.1
 
 mockitoVersion = 2.0.90-beta
 junitVersion = 4.12


### PR DESCRIPTION
Flogger is significantly cleaner than standard logging, which we seem to have established as being error prone when passing in string format args.