### PR TITLE
Upgrade Gradle version to 5.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install test versions to Maven for easier dependency management, simply run:
 Java Versions
 -------------
 
-Java 7 or above is required for using this library.
+Java 8 or above is required for using this library.
 
 Contributing
 ------------

--- a/endpoints-auth/build.gradle
+++ b/endpoints-auth/build.gradle
@@ -64,7 +64,7 @@ sourceSets {
 }
 
 task integrationTest(type: Test) {
-  testClassesDir = sourceSets.integrationTest.output.classesDir
+  testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
   outputs.upToDateWhen { false }
 }

--- a/endpoints-control-api-client/build.gradle
+++ b/endpoints-control-api-client/build.gradle
@@ -18,7 +18,7 @@ buildscript {
   repositories {
     mavenCentral()
   }
-  dependencies { classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.7' }
+  dependencies { classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10' }
 }
 archivesBaseName = 'endpoints-management-api-client'
 

--- a/endpoints-control/build.gradle
+++ b/endpoints-control/build.gradle
@@ -18,7 +18,7 @@ buildscript {
   repositories {
     mavenCentral()
   }
-  dependencies { classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.7' }
+  dependencies { classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10' }
 }
 
 configureMaven(
@@ -48,7 +48,8 @@ processResources {
 }
 
 dependencies {
-  compileOnly "com.google.auto.value:auto-value:${autoValueVersion}"
+  compile "com.google.auto.value:auto-value-annotations:${autoValueVersion}"
+  annotationProcessor "com.google.auto.value:auto-value:${autoValueVersion}"
   compile "com.google.code.findbugs:jsr305:${jsr305Version}"
   compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
   compile "com.google.flogger:flogger:${floggerVersion}"

--- a/endpoints-management-control-all/build.gradle
+++ b/endpoints-management-control-all/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id 'com.github.johnrengelman.shadow' version '1.2.3'
+  id 'com.github.johnrengelman.shadow' version '5.1.0'
 }
 
 configurations {

--- a/endpoints-management-control-appengine-all/build.gradle
+++ b/endpoints-management-control-appengine-all/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id 'com.github.johnrengelman.shadow' version '1.2.3'
+  id 'com.github.johnrengelman.shadow' version '5.1.0'
 }
 
 configurations {

--- a/endpoints-management-protos/build.gradle
+++ b/endpoints-management-protos/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenCentral()
   }
-  dependencies { classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.7' }
+  dependencies { classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10' }
 }
 
 apply plugin: 'java'

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ targetCompatibility=1.7
 
 version = 1.0.11
 appengineSdkVersion = 1.9.56
-autoValueVersion = 1.1
+autoValueVersion = 1.6.6
 bouncycastleVersion = 1.54
 commonsLang3Version = 3.4
 googleApiClientProtobufVersion = 1.22.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 08 15:32:03 PDT 2016
+#Wed Sep 04 19:51:56 MDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip


### PR DESCRIPTION
This commit also adjusts build.gradle files, so that they are compatible
with the new Gradle version.

Protobuf plugin now requires Java 8. This is reflected in README.md

I've checked the new configuration works by invoking Gradle tasks:
project tasks build check clean eclipse javadoc.