### PR TITLE
Remove service serialization to debug log in ConfigFilter

### DIFF
--- a/endpoints-control/src/main/java/com/google/api/control/ConfigFilter.java
+++ b/endpoints-control/src/main/java/com/google/api/control/ConfigFilter.java
@@ -110,7 +110,7 @@ public class ConfigFilter implements Filter {
       httpRequest.setAttribute(SERVICE_NAME_ATTRIBUTE, theService.getName());
       httpRequest.setAttribute(REGISTRY_ATTRIBUTE, registry);
       httpRequest.setAttribute(REPORTING_ATTRIBUTE, rule);
-      log.atFine().log("Added service %s, and associated attributes to the request", theService);
+      log.atFine().log("Added service %s, and associated attributes to the request", theService.getName());
 
       // Determine if service control is required
       String uri = httpRequest.getRequestURI();


### PR DESCRIPTION
The ConfigFilter used to print a whole string serialization of the
corresponding service object to the debug (fine) log. As the service object can
become very large, this consumes many CPU cycles even when the debug log
is not enabled.

In our productive application, the trace consumes about 1/3 of all our CPU cycles, 
which is not acceptable for a disabled log message.

As the log message with thousands of rows is not readable anyway, only the
service's name will be printed to the log now.