### PR TITLE
Ignore unknown fields when parsing service config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,8 @@ subprojects {
       protobufJavaBom: "com.google.protobuf:protobuf-bom:${protobufJavaVersion}",
       protobufJava: "com.google.protobuf:protobuf-java",
       protobufJavaUtil: "com.google.protobuf:protobuf-java-util",
+
+      javaAnnotations: "javax.annotation:javax.annotation-api:${javaAnnotationVersion}"
     ]
   }
 }

--- a/endpoints-management-protos/build.gradle
+++ b/endpoints-management-protos/build.gradle
@@ -27,6 +27,8 @@ dependencies {
   compile platform(libraries.grpcBom),
           libraries.grpcStub,
           libraries.grpcProtobuf
+
+  implementation libraries.javaAnnotations
 }
 
 protobuf {

--- a/endpoints-service-config/src/main/java/com/google/api/config/ServiceConfigSupplier.java
+++ b/endpoints-service-config/src/main/java/com/google/api/config/ServiceConfigSupplier.java
@@ -191,7 +191,7 @@ public final class ServiceConfigSupplier implements Supplier<Service> {
   private static Service parseHttpResponse(HttpResponse httpResponse) {
     try {
       Builder builder = Service.newBuilder();
-      JsonFormat.parser().merge(httpResponse.parseAsString(), builder);
+      JsonFormat.parser().ignoringUnknownFields().merge(httpResponse.parseAsString(), builder);
       return builder.build();
     } catch (IOException exception) {
       throw new ServiceConfigException(

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,7 @@ servletApiVersion = 2.5
 truthVersion = 0.27
 endpointsFrameworkVersion = 2.0.1
 floggerVersion=0.3.1
+javaAnnotationVersion=1.3.2
 
 mockitoVersion = 2.0.90-beta
 junitVersion = 4.12


### PR DESCRIPTION
Newer versions of service config provide fields that don't map to the Protos currently in the repo.