### PR TITLE
Fix warnings for invalid dependencies in endpoints-managment-protos

### DIFF
--- a/endpoints-service-config/build.gradle
+++ b/endpoints-service-config/build.gradle
@@ -23,13 +23,14 @@ archivesBaseName = 'endpoints-management-config'
 
 dependencies {
   compile(project(":endpoints-management-protos"))
-  compile platform(libraries.protobufJavaBom)
-  compile "com.google.protobuf:protobuf-java"
+  compile platform(libraries.protobufJavaBom),
+          libraries.protobufJava,
+          libraries.protobufJavaUtil
+
   compile "com.google.apis:google-api-services-servicemanagement:$servicemanagementVersion"
   compileOnly "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"
   compile "com.google.guava:guava:$guavaVersion"
   compile "com.google.http-client:google-http-client:$httpClientVersion"
-  compile "com.google.protobuf:protobuf-java-util"
 
   testCompile "org.mockito:mockito-core:$mockitoVersion"
   testCompile "junit:junit:$junitVersion"


### PR DESCRIPTION
Compiled it locally and found version 3.9.1 is included in the pom.xml