### PR TITLE
Fix the broken profobuf dependency in 1.0.16

### DIFF
--- a/endpoints-service-config/build.gradle
+++ b/endpoints-service-config/build.gradle
@@ -23,9 +23,7 @@ archivesBaseName = 'endpoints-management-config'
 
 dependencies {
   compile(project(":endpoints-management-protos"))
-  compile platform(libraries.protobufJavaBom),
-          libraries.protobufJava,
-          libraries.protobufJavaUtil
+  compile libraries.protobufJavaUtil
 
   compile "com.google.apis:google-api-services-servicemanagement:$servicemanagementVersion"
   compileOnly "com.google.appengine:appengine-api-1.0-sdk:$appengineSdkVersion"


### PR DESCRIPTION
Verified the required jars are included in the transitive dependency


[INFO] --------------------< com.google.endpoints:fake-id >--------------------
[INFO] Building fake-id 1.0.17
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The POM for com.google.endpoints:endpoints-management-protos:jar:1.0.17 is missing, no dependency information available
[INFO]
[INFO] --- dependency:3.7.0:tree (default-cli) @ fake-id ---
[INFO] com.google.endpoints:fake-id:jar:1.0.17
[INFO] +- com.google.endpoints:endpoints-management-protos:jar:1.0.17:compile
[INFO] +- com.google.protobuf:protobuf-java-util:jar:3.9.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.9.1:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.3.2:compile
[INFO] |  \- com.google.code.gson:gson:jar:2.7:compile
[INFO] +- com.google.apis:google-api-services-servicemanagement:jar:v1-rev14-1.22.0:compile
[INFO] |  \- com.google.api-client:google-api-client:jar:1.22.0:compile
[INFO] |     +- com.google.oauth-client:google-oauth-client:jar:1.22.0:compile
[INFO] |     +- com.google.http-client:google-http-client-jackson2:jar:1.22.0:compile
[INFO] |     |  \- com.fasterxml.jackson.core:jackson-core:jar:2.1.3:compile
[INFO] |     \- com.google.guava:guava-jdk5:jar:17.0:compile
[INFO] +- com.google.guava:guava:jar:19.0:compile
[INFO] +- com.google.http-client:google-http-client:jar:1.22.0:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:1.3.9:compile
[INFO] |  \- org.apache.httpcomponents:httpclient:jar:4.0.1:compile
[INFO] |     +- org.apache.httpcomponents:httpcore:jar:4.0.1:compile
[INFO] |     +- commons-logging:commons-logging:jar:1.1.1:compile
[INFO] |     \- commons-codec:commons-codec:jar:1.3:compile
[INFO] +- org.mockito:mockito-core:jar:2.0.90-beta:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.4.8:test
[INFO] |  \- org.objenesis:objenesis:jar:2.4:test
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] \- com.google.truth:truth:jar:0.27:test